### PR TITLE
Fix custom pan recipe texture

### DIFF
--- a/java/mods/defeatedcrow/common/tile/appliance/TilePanG.java
+++ b/java/mods/defeatedcrow/common/tile/appliance/TilePanG.java
@@ -129,7 +129,14 @@ public class TilePanG extends TileEntity
         	if (recipe != null)
         	{
         		String s = recipe.getTex();
-        		this.tex = "defeatedcrow:textures/blocks/contents_" + s + ".png";
+                if (s.contains(":"))
+                {
+                    this.tex = s;
+                }
+                else
+                {
+                    this.tex = "defeatedcrow:textures/blocks/contents_" + s + ".png";
+                }
         	}
         	else
         	{


### PR DESCRIPTION
Should fix custom textures when adding recipes via the API (so it works like documented, with the full asset path).

Note: I have trouble to compile AMT myself, so I haven't tested it. To my best knowledge it should work though.