### PR TITLE
Allow custom items to act as a bamboo basket without BambooMod

### DIFF
--- a/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan.java
+++ b/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan.java
@@ -68,7 +68,7 @@ public class BlockFilledPan extends BlockContainer{
     		par1World.playSoundAtEntity(par5EntityPlayer, "random.pop", 0.4F, 1.8F);
     		return true;
         }
-        else if (DCsAppleMilk.SuccessLoadBamboo && LoadBambooPlugin.bambooBasket != null && itemstack.getItem() == LoadBambooPlugin.bambooBasket.getItem())
+        else if (LoadBambooPlugin.bambooBasket != null && itemstack.getItem() == LoadBambooPlugin.bambooBasket.getItem())
         {
         	this.getJPStew(par1World, par2, par3, par4, par5EntityPlayer, itemstack, currentMeta);
 			this.setPanEmpty(par1World, par2, par3, par4, currentMeta);

--- a/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan.java
+++ b/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan.java
@@ -197,20 +197,20 @@ public class BlockFilledPan extends BlockContainer{
 		}
 		else
 		{
-            if (LoadBambooPlugin.bambooBasket != null)
-            {
-                if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
-                {
-                    player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
-                }
-            }
-            else
-            {
-                if (!player.inventory.addItemStackToInventory(new ItemStack(Items.bowl,1)))
-                {
-                    player.entityDropItem(new ItemStack(Items.bowl,1), 1);
-                }
-            }
+			if (LoadBambooPlugin.bambooBasket != null)
+			{
+				if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
+				{
+					player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
+				}
+			}
+			else
+			{
+				if (!player.inventory.addItemStackToInventory(new ItemStack(Items.bowl,1)))
+				{
+					player.entityDropItem(new ItemStack(Items.bowl,1), 1);
+				}
+			}
 		}
 		
 		world.playSoundAtEntity(player, "random.pop", 0.4F, 1.8F);

--- a/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan.java
+++ b/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan.java
@@ -197,10 +197,20 @@ public class BlockFilledPan extends BlockContainer{
 		}
 		else
 		{
-			if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
-			{
-				player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
-			}
+            if (LoadBambooPlugin.bambooBasket != null)
+            {
+                if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
+                {
+                    player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
+                }
+            }
+            else
+            {
+                if (!player.inventory.addItemStackToInventory(new ItemStack(Items.bowl,1)))
+                {
+                    player.entityDropItem(new ItemStack(Items.bowl,1), 1);
+                }
+            }
 		}
 		
 		world.playSoundAtEntity(player, "random.pop", 0.4F, 1.8F);

--- a/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan2.java
+++ b/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan2.java
@@ -195,20 +195,20 @@ public class BlockFilledPan2 extends BlockContainer{
 		}
 		else
 		{
-            if (LoadBambooPlugin.bambooBasket != null)
-            {
-                if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
-                {
-                    player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
-                }
-            }
-            else
-            {
-                if (!player.inventory.addItemStackToInventory(new ItemStack(Items.bowl,1)))
-                {
-                    player.entityDropItem(new ItemStack(Items.bowl,1), 1);
-                }
-            }
+			if (LoadBambooPlugin.bambooBasket != null)
+			{
+				if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
+				{
+					player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
+				}
+			}
+			else
+			{
+				if (!player.inventory.addItemStackToInventory(new ItemStack(Items.bowl,1)))
+				{
+					player.entityDropItem(new ItemStack(Items.bowl,1), 1);
+				}
+			}
 		}
 		
 		world.playSoundAtEntity(player, "random.pop", 0.4F, 1.8F);

--- a/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan2.java
+++ b/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan2.java
@@ -66,7 +66,7 @@ public class BlockFilledPan2 extends BlockContainer{
     		par1World.playSoundAtEntity(par5EntityPlayer, "random.pop", 0.4F, 1.8F);
     		return true;
         }
-        else if (DCsAppleMilk.SuccessLoadBamboo && LoadBambooPlugin.bambooBasket != null && itemstack.getItem() == LoadBambooPlugin.bambooBasket.getItem())
+        else if (LoadBambooPlugin.bambooBasket != null && itemstack.getItem() == LoadBambooPlugin.bambooBasket.getItem())
         {
         	this.getJPStew(par1World, par2, par3, par4, par5EntityPlayer, itemstack, currentMeta);
 			this.setPanEmpty(par1World, par2, par3, par4, currentMeta);

--- a/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan2.java
+++ b/java/mods/defeatedcrow/common/block/appliance/BlockFilledPan2.java
@@ -195,10 +195,20 @@ public class BlockFilledPan2 extends BlockContainer{
 		}
 		else
 		{
-			if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
-			{
-				player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
-			}
+            if (LoadBambooPlugin.bambooBasket != null)
+            {
+                if (!player.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
+                {
+                    player.entityDropItem(LoadBambooPlugin.bambooBasket.copy(), 1);
+                }
+            }
+            else
+            {
+                if (!player.inventory.addItemStackToInventory(new ItemStack(Items.bowl,1)))
+                {
+                    player.entityDropItem(new ItemStack(Items.bowl,1), 1);
+                }
+            }
 		}
 		
 		world.playSoundAtEntity(player, "random.pop", 0.4F, 1.8F);

--- a/java/mods/defeatedcrow/common/block/edible/BlockBowlJP.java
+++ b/java/mods/defeatedcrow/common/block/edible/BlockBowlJP.java
@@ -70,7 +70,7 @@ public class BlockBowlJP extends BlockContainer{
         {
         	if (currentMeta == 15)
         	{
-        		if (DCsAppleMilk.SuccessLoadBamboo && LoadBambooPlugin.bambooBasket != null)
+        		if (LoadBambooPlugin.bambooBasket != null)
         		{
         			if (!par5EntityPlayer.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
                 	{
@@ -101,7 +101,7 @@ public class BlockBowlJP extends BlockContainer{
         {
         	if (currentMeta == 15)
         	{
-        		if (DCsAppleMilk.SuccessLoadBamboo && LoadBambooPlugin.bambooBasket != null)
+        		if (LoadBambooPlugin.bambooBasket != null)
         		{
         			if (!par5EntityPlayer.inventory.addItemStackToInventory(LoadBambooPlugin.bambooBasket.copy()))
                 	{

--- a/java/mods/defeatedcrow/common/block/edible/EntityItemBowlJP.java
+++ b/java/mods/defeatedcrow/common/block/edible/EntityItemBowlJP.java
@@ -19,7 +19,7 @@ public class EntityItemBowlJP extends EdibleEntityItemBlock2{
 		setMaxDamage(0);
 		setHasSubtypes(true);
 		
-		if (DCsAppleMilk.SuccessLoadBamboo && LoadBambooPlugin.bambooBasket != null) {
+		if (LoadBambooPlugin.bambooBasket != null) {
 			setContainerItem(LoadBambooPlugin.bambooBasket.getItem());
 		}
 		else {
@@ -35,7 +35,7 @@ public class EntityItemBowlJP extends EdibleEntityItemBlock2{
 	@Override
 	public ItemStack getReturnContainer(int meta) {
 		
-		return (DCsAppleMilk.SuccessLoadBamboo && LoadBambooPlugin.bambooBasket != null) ? LoadBambooPlugin.bambooBasket.copy(): new ItemStack(Items.bowl, 1, 0);
+		return (LoadBambooPlugin.bambooBasket != null) ? LoadBambooPlugin.bambooBasket.copy(): new ItemStack(Items.bowl, 1, 0);
 	}
 	
 	@Override


### PR DESCRIPTION
These changes allow me to set ```LoadBambooPlugin.bambooBasket``` and have an item work like the bamboo basket without having BambooMod. Checking ```LoadBambooPlugin.bambooBasket``` for ```null``` should be sufficient to make sure everything works as intended.